### PR TITLE
Handle resource alias not found error

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,1 +1,10 @@
+from rich.console import Console
+
+CONSOLE = Console()
+
 ALIASES_FILE_PATH = "app/manifests/aliases.json"
+
+HOW_TO_UPDATE_ALIASES_MESSAGE = (
+    "How to update the resource aliases file: "
+    "https://github.com/RedHatQE/must-gather-explorer?tab=readme-ov-file#update-cluster-resources-aliases\n"
+)

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,14 @@
+class MissingResourceKindAliasError(Exception):
+    def __init__(self, requested_kind: str) -> None:
+        self.requested_kind = requested_kind
+
+    def __repr__(self) -> str:
+        return f"Resource kind alias '{self.requested_kind}' not found"
+
+
+class FailToReadJSONFileError(Exception):
+    def __init__(self, file_name: str) -> None:
+        self.file_name = file_name
+
+    def __repr__(self) -> str:
+        return f"Can't read file '{self.file_name}'"

--- a/app/resource_aliases.py
+++ b/app/resource_aliases.py
@@ -5,11 +5,9 @@ from typing import Dict, List
 
 import click
 from pyhelper_utils.shell import run_command
-from rich.console import Console
 
-from app.constants import ALIASES_FILE_PATH
-
-CONSOLE = Console()
+from app.constants import ALIASES_FILE_PATH, CONSOLE
+from app.utils import read_aliases_file
 
 
 @click.command("update-resources-aliases")
@@ -22,11 +20,7 @@ def fill_api_resources_aliases() -> None:
         CONSOLE.print(f"Error message: {err}")
         sys.exit(1)
 
-    try:
-        with open(ALIASES_FILE_PATH) as aliases_file:
-            resources_aliases = json.load(aliases_file)
-    except Exception:
-        resources_aliases = {}
+    resources_aliases = read_aliases_file(raise_on_error=False)
 
     cli_resource_alias: Dict[str, List[str]] = {}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,19 @@
+import json
+
+from app.constants import ALIASES_FILE_PATH, HOW_TO_UPDATE_ALIASES_MESSAGE, CONSOLE
+from app.exceptions import FailToReadJSONFileError
+
+
+def read_aliases_file(raise_on_error: bool = True) -> dict[str, list[str]]:
+    try:
+        with open(ALIASES_FILE_PATH) as aliases_file:
+            return json.load(aliases_file)
+    except (FileNotFoundError, json.JSONDecodeError) as exp:
+        if raise_on_error:
+            CONSOLE.print(
+                f"[bold red]Error:[/bold red] Can't read the aliases_file\n"
+                f"Error details: {exp}\n"
+                f"{HOW_TO_UPDATE_ALIASES_MESSAGE}"
+            )
+            raise FailToReadJSONFileError(file_name=ALIASES_FILE_PATH)
+        return {}


### PR DESCRIPTION
- Add an exception for read alias file
- Add an exception for alias not found 
- Move read alias file to utils

Fix https://github.com/RedHatQE/must-gather-explorer/issues/10
Fix https://github.com/RedHatQE/must-gather-explorer/issues/15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new exception classes for improved error handling: `MissingResourceKindAliasError` and `FailToReadJSONFileError`.
  
- **Bug Fixes**
	- Enhanced error handling in the main function to prevent abrupt program termination and allow for continued user interaction in case of specific errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->